### PR TITLE
Metadata browsing tools, per-instance connection filter, and multi-instance HTTP

### DIFF
--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/DbeaverMcpApplication.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/DbeaverMcpApplication.java
@@ -16,16 +16,48 @@ import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerA
         DataSourceTransactionManagerAutoConfiguration.class,
 })
 public class DbeaverMcpApplication {
-    private static final int HTTP_PORT = 8790;
+    private static final int DEFAULT_HTTP_PORT = 8790;
 
     @SuppressWarnings("UnnecessaryModifier")
     public static void main(String[] args) {
-        boolean httpAvailable = NetworkUtils.isPortAvailable(HTTP_PORT);
+        int httpPort = resolveServerPort(args);
+        boolean httpAvailable = NetworkUtils.isPortAvailable(httpPort);
 
         SpringApplication app = new SpringApplication(DbeaverMcpApplication.class);
         app.setWebApplicationType(httpAvailable ? WebApplicationType.SERVLET : WebApplicationType.NONE);
 
-        log.info("Starting MCP. HTTP available = {}", httpAvailable);
+        log.info("Starting MCP. Port {}, HTTP available = {}", httpPort, httpAvailable);
         app.run(args);
+    }
+
+    /**
+     * Resolves the effective HTTP port so the web-vs-stdio decision keys off the port this
+     * instance would actually bind, not a fixed one. This lets several instances run as HTTP
+     * servers on different ports. Precedence: {@code --server.port} arg, {@code SERVER_PORT}
+     * env, {@code server.port} system property, else {@value #DEFAULT_HTTP_PORT}.
+     */
+    private static int resolveServerPort(String[] args) {
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (arg.startsWith("--server.port=")) {
+                return parsePort(arg.substring("--server.port=".length()));
+            }
+            if (arg.equals("--server.port") && i + 1 < args.length) {
+                return parsePort(args[i + 1]);
+            }
+        }
+        String env = System.getenv("SERVER_PORT");
+        if (env != null && !env.isBlank()) return parsePort(env);
+        String sys = System.getProperty("server.port");
+        if (sys != null && !sys.isBlank()) return parsePort(sys);
+        return DEFAULT_HTTP_PORT;
+    }
+
+    private static int parsePort(String value) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return DEFAULT_HTTP_PORT;
+        }
     }
 }

--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/filter/ConnectionFilter.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/filter/ConnectionFilter.java
@@ -1,0 +1,49 @@
+package dev.felipeflohr.dbeavermcp.module.connection.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Decides whether a DBeaver connection is accessible from this MCP instance, based on the
+ * include/exclude regex lists in {@link ConnectionFilterProperties}. Used both when listing
+ * connections and when resolving a connection for a query, so a hidden connection cannot be
+ * reached even by naming it directly.
+ */
+@Slf4j
+@NullMarked
+@Service
+public class ConnectionFilter {
+    private final List<Pattern> include;
+    private final List<Pattern> exclude;
+
+    public ConnectionFilter(ConnectionFilterProperties properties) {
+        this.include = compile(properties.getInclude());
+        this.exclude = compile(properties.getExclude());
+        if (!include.isEmpty() || !exclude.isEmpty()) {
+            log.info("Connection filter active. include={} exclude={}", properties.getInclude(), properties.getExclude());
+        }
+    }
+
+    public boolean isAllowed(@Nullable String connectionName) {
+        if (connectionName == null) return false;
+        boolean included = include.isEmpty() || include.stream().anyMatch(p -> p.matcher(connectionName).find());
+        if (!included) return false;
+        return exclude.stream().noneMatch(p -> p.matcher(connectionName).find());
+    }
+
+    private static List<Pattern> compile(@Nullable List<String> regexes) {
+        List<Pattern> compiled = new ArrayList<>();
+        if (regexes == null) return compiled;
+        for (String regex : regexes) {
+            if (regex == null || regex.isBlank()) continue;
+            compiled.add(Pattern.compile(regex.trim(), Pattern.CASE_INSENSITIVE));
+        }
+        return compiled;
+    }
+}

--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/filter/ConnectionFilterProperties.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/filter/ConnectionFilterProperties.java
@@ -1,0 +1,26 @@
+package dev.felipeflohr.dbeavermcp.module.connection.filter;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Per-instance allow/deny lists that limit which DBeaver connections this MCP instance exposes.
+ * Configure via args or env, e.g.
+ * {@code --dbeavermcp.connections.include=^prod,^staging} and/or
+ * {@code --dbeavermcp.connections.exclude=legacy}.
+ * Each entry is a regex matched (case-insensitive, substring via {@code find()}) against the
+ * connection NAME. Empty {@code include} means all connections are allowed.
+ * <p>Note: commas separate list entries, so avoid {@code {m,n}} quantifiers in a comma-joined
+ * value (use the indexed form {@code include[0]=...} if you need them).
+ */
+@Component
+@ConfigurationProperties(prefix = "dbeavermcp.connections")
+@Data
+public class ConnectionFilterProperties {
+    private List<String> include = new ArrayList<>();
+    private List<String> exclude = new ArrayList<>();
+}

--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/manager/ConnectionManagerImpl.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/connection/manager/ConnectionManagerImpl.java
@@ -3,6 +3,7 @@ package dev.felipeflohr.dbeavermcp.module.connection.manager;
 import dev.felipeflohr.dbeavermcp.exception.DBeaverMCPValidationException;
 import dev.felipeflohr.dbeavermcp.module.connection.datasource.DBeaverMCPDatasource;
 import dev.felipeflohr.dbeavermcp.module.connection.enumeration.DatabaseType;
+import dev.felipeflohr.dbeavermcp.module.connection.filter.ConnectionFilter;
 import dev.felipeflohr.dbeaverconfig.data.auth.DBeaverAuthConnectionData;
 import dev.felipeflohr.dbeaverconfig.data.auth.DBeaverAuthSSHTunnel;
 import dev.felipeflohr.dbeaverconfig.data.datasource.DBeaverConnection;
@@ -31,6 +32,7 @@ class ConnectionManagerImpl implements ConnectionManager {
     private final DBeaverDataSourceService dBeaverDataSourceService;
     private final DBeaverCipherService dBeaverCipherService;
     private final SSHTunnelManager sshTunnelManager;
+    private final ConnectionFilter connectionFilter;
 
     @Override
     public DataSource getDataSourceFromConnectionName(String connectionName) throws DBeaverMCPValidationException {
@@ -68,6 +70,9 @@ class ConnectionManagerImpl implements ConnectionManager {
 
 
     private String getIdentifierFromConnectionName(String connectionName) throws DBeaverMCPValidationException {
+        if (!connectionFilter.isAllowed(connectionName)) {
+            throw new DBeaverMCPValidationException("Connection \"%s\" is not accessible from this MCP instance (filtered by dbeavermcp.connections).".formatted(connectionName));
+        }
         DBeaverDataSources dataSources = dBeaverDataSourceService.getDataSources();
         Optional<String> connectionIdentifierOpt = dataSources.getConnections().entrySet().stream()
                 .filter(e -> e.getValue().getName().equals(connectionName))

--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/metadata/mcp/MetadataMCPService.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/metadata/mcp/MetadataMCPService.java
@@ -1,0 +1,191 @@
+package dev.felipeflohr.dbeavermcp.module.metadata.mcp;
+
+import dev.felipeflohr.dbeavermcp.exception.DBeaverMCPValidationException;
+import dev.felipeflohr.dbeavermcp.module.query.factory.QueryServiceFactory;
+import dev.felipeflohr.dbeavermcp.module.query.model.StatementResponseDTO;
+import dev.felipeflohr.dbeavermcp.module.query.service.QueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Metadata browsing tools for Oracle connections. All tools delegate to the existing read-only
+ * query path ({@link QueryService#executeReadOnlyStatements}), so they inherit the Oracle
+ * {@code SET TRANSACTION READ ONLY} enforcement, CLOB handling and connection resolution.
+ * SQL is built from validated identifiers (no bind parameters are available on that path);
+ * every statement is a SELECT, so no DDL/DML can be injected.
+ */
+@Slf4j
+@SuppressWarnings("unused")
+@NullMarked
+@RequiredArgsConstructor
+@Service
+public class MetadataMCPService {
+    private static final Pattern IDENT = Pattern.compile("^[A-Za-z0-9_$#]+$");
+    private static final Set<String> DDL_TYPES = Set.of(
+            "TABLE", "VIEW", "MATERIALIZED_VIEW", "INDEX", "SEQUENCE", "TRIGGER",
+            "PROCEDURE", "FUNCTION", "PACKAGE", "PACKAGE_BODY", "TYPE", "TYPE_BODY",
+            "SYNONYM", "CONSTRAINT");
+
+    private final QueryServiceFactory queryServiceFactory;
+
+    @McpTool(
+            name = "list_schemas",
+            description = "Lists the database schemas/owners visible on a DBeaver connection (Oracle). " +
+                    "Use a connection name returned by 'list_available_connections'."
+    )
+    public List<StatementResponseDTO> listSchemas(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName
+    ) throws Exception {
+        return run(connectionName, List.of("SELECT username AS SCHEMA_NAME FROM all_users ORDER BY username"));
+    }
+
+    @McpTool(
+            name = "list_tables",
+            description = "Lists tables on a connection (Oracle). Optional 'owner' (defaults to the connection's " +
+                    "current schema) and optional 'namePattern' (case-insensitive LIKE; % and _ wildcards allowed, " +
+                    "wrapped in % automatically if none given)."
+    )
+    public List<StatementResponseDTO> listTables(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName,
+            @McpToolParam(description = "Optional schema/owner; defaults to the current schema", required = false) @Nullable String owner,
+            @McpToolParam(description = "Optional table name filter (case-insensitive LIKE)", required = false) @Nullable String namePattern
+    ) throws Exception {
+        StringBuilder sql = new StringBuilder("SELECT owner, table_name FROM all_tables WHERE owner = ")
+                .append(ownerExpr(owner));
+        if (isSet(namePattern)) sql.append(" AND UPPER(table_name) LIKE ").append(likeLit(namePattern));
+        sql.append(" ORDER BY owner, table_name");
+        return run(connectionName, List.of(sql.toString()));
+    }
+
+    @McpTool(
+            name = "describe_table",
+            description = "Describes a table (Oracle): returns 3 result sets - (1) columns with data type, length/precision, " +
+                    "nullable, default and column comment; (2) PK/FK/unique constraints with columns and referenced table; " +
+                    "(3) the table comment."
+    )
+    public List<StatementResponseDTO> describeTable(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName,
+            @McpToolParam(description = "Table name") String tableName,
+            @McpToolParam(description = "Optional schema/owner; defaults to the current schema", required = false) @Nullable String owner
+    ) throws Exception {
+        String t = lit(ident(tableName, "tableName"));
+        String o = ownerExpr(owner);
+        String columns = "SELECT c.column_id, c.column_name, c.data_type, c.data_length, c.data_precision, " +
+                "c.data_scale, c.nullable, c.data_default, cc.comments AS column_comment " +
+                "FROM all_tab_columns c " +
+                "LEFT JOIN all_col_comments cc ON cc.owner = c.owner AND cc.table_name = c.table_name AND cc.column_name = c.column_name " +
+                "WHERE c.owner = " + o + " AND c.table_name = " + t + " ORDER BY c.column_id";
+        String constraints = "SELECT ac.constraint_type, ac.constraint_name, acc.column_name, acc.position, " +
+                "ac.r_owner, ac.r_constraint_name, " +
+                "(SELECT rc.table_name FROM all_constraints rc WHERE rc.owner = ac.r_owner AND rc.constraint_name = ac.r_constraint_name) AS referenced_table " +
+                "FROM all_constraints ac " +
+                "JOIN all_cons_columns acc ON acc.owner = ac.owner AND acc.constraint_name = ac.constraint_name AND acc.table_name = ac.table_name " +
+                "WHERE ac.owner = " + o + " AND ac.table_name = " + t + " AND ac.constraint_type IN ('P','R','U') " +
+                "ORDER BY ac.constraint_type, ac.constraint_name, acc.position";
+        String tableComment = "SELECT comments AS table_comment FROM all_tab_comments WHERE owner = " + o + " AND table_name = " + t;
+        return run(connectionName, List.of(columns, constraints, tableComment));
+    }
+
+    @McpTool(
+            name = "get_ddl",
+            description = "Returns the DDL of a database object via DBMS_METADATA.GET_DDL (Oracle). " +
+                    "objectType is one of TABLE, VIEW, MATERIALIZED_VIEW, INDEX, SEQUENCE, TRIGGER, PROCEDURE, " +
+                    "FUNCTION, PACKAGE, PACKAGE_BODY, TYPE, TYPE_BODY, SYNONYM, CONSTRAINT."
+    )
+    public List<StatementResponseDTO> getDdl(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName,
+            @McpToolParam(description = "Object type (e.g. TABLE, VIEW, PACKAGE, PACKAGE_BODY, TRIGGER, FUNCTION, PROCEDURE)") String objectType,
+            @McpToolParam(description = "Object name") String objectName,
+            @McpToolParam(description = "Optional schema/owner; defaults to the current schema", required = false) @Nullable String owner
+    ) throws Exception {
+        String type = ident(objectType, "objectType");
+        if (!DDL_TYPES.contains(type)) {
+            throw new DBeaverMCPValidationException("Unsupported objectType '%s'. Allowed: %s".formatted(objectType, DDL_TYPES));
+        }
+        String name = lit(ident(objectName, "objectName"));
+        String sql = "SELECT DBMS_METADATA.GET_DDL(" + lit(type) + ", " + name + ", " + ownerExpr(owner) + ") AS DDL FROM dual";
+        return run(connectionName, List.of(sql));
+    }
+
+    @McpTool(
+            name = "count_rows",
+            description = "Counts rows in a table (Oracle), with an optional WHERE clause. Read-only."
+    )
+    public List<StatementResponseDTO> countRows(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName,
+            @McpToolParam(description = "Table name") String tableName,
+            @McpToolParam(description = "Optional schema/owner; defaults to the current schema", required = false) @Nullable String owner,
+            @McpToolParam(description = "Optional WHERE clause WITHOUT the 'WHERE' keyword, e.g. \"STATO = 'A'\"", required = false) @Nullable String whereClause
+    ) throws Exception {
+        String t = ident(tableName, "tableName");
+        String from = isSet(owner) ? "\"" + ident(owner, "owner") + "\".\"" + t + "\"" : "\"" + t + "\"";
+        StringBuilder sql = new StringBuilder("SELECT COUNT(*) AS ROW_COUNT FROM ").append(from);
+        if (isSet(whereClause)) sql.append(" WHERE ").append(whereClause);
+        return run(connectionName, List.of(sql.toString()));
+    }
+
+    @McpTool(
+            name = "search_objects",
+            description = "Finds tables and columns whose name matches a pattern (Oracle, case-insensitive LIKE). " +
+                    "Returns 2 result sets: matching tables, then matching columns. Optional 'owner' restricts the search."
+    )
+    public List<StatementResponseDTO> searchObjects(
+            @McpToolParam(description = "The DBeaver connection name") String connectionName,
+            @McpToolParam(description = "Name pattern (case-insensitive; % and _ wildcards allowed, wrapped in % if none given)") String namePattern,
+            @McpToolParam(description = "Optional schema/owner to restrict the search", required = false) @Nullable String owner
+    ) throws Exception {
+        String like = likeLit(namePattern);
+        String ownerClause = isSet(owner) ? " AND owner = " + lit(ident(owner, "owner")) : "";
+        String tables = "SELECT owner, table_name FROM all_tables WHERE UPPER(table_name) LIKE " + like + ownerClause +
+                " ORDER BY owner, table_name";
+        String columns = "SELECT owner, table_name, column_name FROM all_tab_columns WHERE UPPER(column_name) LIKE " + like + ownerClause +
+                " ORDER BY owner, table_name, column_name";
+        return run(connectionName, List.of(tables, columns));
+    }
+
+    private List<StatementResponseDTO> run(String connectionName, List<String> sqls) throws DBeaverMCPValidationException {
+        QueryService queryService = queryServiceFactory.getFromConnectionName(connectionName);
+        return queryService.executeReadOnlyStatements(sqls, connectionName, 60);
+    }
+
+    private static boolean isSet(@Nullable String s) {
+        return s != null && !s.isBlank();
+    }
+
+    /** Validates a SQL identifier (owner/table/object/type) and upper-cases it. */
+    private static String ident(String raw, String what) throws DBeaverMCPValidationException {
+        String v = raw == null ? "" : raw.trim();
+        if (!IDENT.matcher(v).matches()) {
+            throw new DBeaverMCPValidationException("Invalid %s '%s': only letters, digits and _ $ # are allowed.".formatted(what, raw));
+        }
+        return v.toUpperCase(Locale.ROOT);
+    }
+
+    /** Wraps a value as a single-quoted SQL string literal, escaping embedded quotes. */
+    private static String lit(String raw) {
+        return "'" + raw.replace("'", "''") + "'";
+    }
+
+    /** Builds an upper-cased LIKE literal, wrapping in % when the caller supplied no wildcard. */
+    private static String likeLit(@Nullable String raw) {
+        String v = (raw == null ? "" : raw.trim()).toUpperCase(Locale.ROOT);
+        if (!v.contains("%") && !v.contains("_")) v = "%" + v + "%";
+        return lit(v);
+    }
+
+    /** Owner as a SQL expression: a quoted literal when supplied, otherwise the current schema. */
+    private static String ownerExpr(@Nullable String owner) throws DBeaverMCPValidationException {
+        if (!isSet(owner)) return "SYS_CONTEXT('USERENV','CURRENT_SCHEMA')";
+        return lit(ident(owner, "owner"));
+    }
+}

--- a/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/query/factory/QueryServiceFactory.java
+++ b/dbeaver-mcp/src/main/java/dev/felipeflohr/dbeavermcp/module/query/factory/QueryServiceFactory.java
@@ -1,6 +1,7 @@
 package dev.felipeflohr.dbeavermcp.module.query.factory;
 
 import dev.felipeflohr.dbeavermcp.exception.DBeaverMCPValidationException;
+import dev.felipeflohr.dbeavermcp.module.connection.filter.ConnectionFilter;
 import dev.felipeflohr.dbeavermcp.module.connection.manager.ConnectionManager;
 import dev.felipeflohr.dbeaverconfig.data.datasource.DBeaverConnectionConfigurationHandlers;
 import dev.felipeflohr.dbeaverconfig.data.datasource.DBeaverConnectionConfigurationSSHTunnelHandler;
@@ -27,6 +28,7 @@ public class QueryServiceFactory {
     private final QueryService firebirdQueryServiceImpl;
     private final ConnectionManager connectionManager;
     private final DBeaverDataSourceService dBeaverDataSourceService;
+    private final ConnectionFilter connectionFilter;
 
     public QueryService getFromConnectionName(String connectionName) throws DBeaverMCPValidationException {
         return switch (connectionManager.getDatabaseTypeFromConnectionName(connectionName)) {
@@ -38,6 +40,7 @@ public class QueryServiceFactory {
 
     public List<AvailableConnectionDTO> getAllAvailableConnections() throws DBeaverMCPValidationException {
         return dBeaverDataSourceService.getDataSources().getConnections().entrySet().stream()
+                .filter(e -> connectionFilter.isAllowed(e.getValue().getName()))
                 .filter(e -> {
                     DBeaverConnectionConfigurationSSHTunnelProperties sshProperties = Optional.ofNullable(e.getValue().getConfiguration().getHandlers())
                             .map(DBeaverConnectionConfigurationHandlers::getSshTunnel)


### PR DESCRIPTION
Three independent, backward-compatible improvements. All connection access stays read-only.

## Metadata browsing tools

Adds `MetadataMCPService` with `list_schemas`, `list_tables`, `describe_table`, `get_ddl` (via `DBMS_METADATA.GET_DDL`), `count_rows` and `search_objects` (Oracle).

They delegate to the existing read-only query path, so they inherit the Oracle `SET TRANSACTION READ ONLY` enforcement and CLOB handling. SQL is built from validated identifiers (`^[A-Za-z0-9_$#]+$`) and every statement is a `SELECT`, so no DDL/DML can be injected. `owner` is optional and defaults to the current schema.

## Per-instance connection allow/deny filter

Adds `dbeavermcp.connections.include` / `dbeavermcp.connections.exclude` — lists of case-insensitive regexes matched against the connection name — so a single instance can expose only a subset of the DBeaver connections. Empty `include` means all connections are allowed.

Enforced both in `list_available_connections` and when resolving a connection for a query, so a filtered-out connection cannot be reached even by naming it directly.

## Multi-instance HTTP fix

The web-vs-stdio decision in `DbeaverMcpApplication` probed a hardcoded port `8790`, so a second instance always saw the port busy, started non-web and then exited. It now derives the effective port from `--server.port` / `SERVER_PORT` / `server.port` (default `8790`), so multiple instances can run as HTTP servers on different ports. Single-instance behaviour is unchanged.
